### PR TITLE
feat: Add score tracker to header pong game

### DIFF
--- a/lib/games/pong/game.ts
+++ b/lib/games/pong/game.ts
@@ -29,6 +29,7 @@ export function createGame(width: number, height: number, colors: PongColors, he
   const horizontalPaddleX = width / 2 - halfPaddleLength
 
   return {
+    score: 0,
     width,
     height,
     scale,
@@ -186,6 +187,7 @@ function checkPixelCollisions(game: GameState): Particle[] {
       ball.y - ball.radius < pixel.y + pixel.size
     ) {
       pixel.hit = true
+      game.score++
       
       // Create particles
       createParticles(pixel, newParticles)

--- a/lib/games/pong/renderer.ts
+++ b/lib/games/pong/renderer.ts
@@ -6,7 +6,7 @@ let lastPixelColor = ''
 
 // Optimized renderer with batched rendering and reduced state changes
 export function render(ctx: CanvasRenderingContext2D, game: GameState): void {
-  const { width, height, pixels, ball, paddles, particles, colors } = game
+  const { width, height, pixels, ball, paddles, particles, colors, score } = game
 
   // Clear canvas
   ctx.fillStyle = colors.background
@@ -25,6 +25,17 @@ export function render(ctx: CanvasRenderingContext2D, game: GameState): void {
 
   // Batch render paddles
   renderPaddles(ctx, paddles, colors.paddle)
+
+  // Render score
+  ctx.fillStyle = colors.pixel // NEON_GREEN for text
+  ctx.strokeStyle = colors.hitPixel // DARK_NEON_GREEN for border
+  ctx.lineWidth = 1
+  ctx.font = "24px sans-serif"
+  ctx.textAlign = "left"
+  ctx.textBaseline = "top"
+  const scoreText = `Score: ${score}`
+  ctx.fillText(scoreText, 20, 20)
+  ctx.strokeText(scoreText, 20, 20)
 }
 
 // Optimized pixel rendering with batching by hit state

--- a/lib/games/pong/types.ts
+++ b/lib/games/pong/types.ts
@@ -49,4 +49,5 @@ export interface GameState {
   paddles: Paddle[]
   particles: Particle[]
   colors: PongColors
+  score: number
 }


### PR DESCRIPTION
Implements a score tracker in the header's pong game. The score is displayed in the top-left corner of the canvas using a neon-green color with a thin border.

The score initializes at 0 and increments by 1 each time the pong ball collides with a pixel from the header text.

Changes include:
- Updated `GameState` type to include a `score` field.
- Initialized `score` to 0 in `createGame`.
- Incremented `score` in `checkPixelCollisions` upon collision.
- Added logic to `render` to display the score.