### PR TITLE
test: increase coverage and raise regression floors

### DIFF
--- a/tests/about-header.test.tsx
+++ b/tests/about-header.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { smoothScrollToSection, useScrollSpy } = vi.hoisted(() => ({
+  smoothScrollToSection: vi.fn(),
+  useScrollSpy: vi.fn(() => "skills"),
+}));
+
+vi.mock("@/lib/smooth-scroll", () => ({ smoothScrollToSection }));
+vi.mock("@/hooks/use-scroll-spy", () => ({ useScrollSpy }));
+vi.mock("@/lib/games/pong", () => ({
+  PongGame: ({
+    navbarHeight,
+    headerText,
+  }: {
+    navbarHeight: number;
+    headerText: string[];
+  }) => (
+    <div data-testid="pong-game" data-navbar-height={navbarHeight}>
+      {headerText.join(" / ")}
+    </div>
+  ),
+}));
+
+import { PongHeader } from "@/components/header";
+import { AboutSection } from "@/views/about-section";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: 900,
+  });
+  Object.defineProperty(window, "scrollY", { configurable: true, value: 0 });
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+});
+
+describe("AboutSection", () => {
+  it("renders overview values and drives their hover styles", () => {
+    render(<AboutSection />);
+
+    expect(
+      screen.getByRole("heading", { name: "About Me" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Innovation")).toBeInTheDocument();
+    expect(screen.getByText("Years Experience")).toBeInTheDocument();
+    expect(screen.getByText("10+")).toBeInTheDocument();
+
+    const valueCard = screen
+      .getByText("Innovation")
+      .closest("div[class]")?.parentElement;
+    if (!valueCard) throw new Error("Innovation card was not rendered");
+    fireEvent.mouseEnter(valueCard);
+    expect(valueCard.style.boxShadow).toContain("20px");
+    fireEvent.mouseLeave(valueCard);
+    expect(valueCard.style.boxShadow).toContain("10px");
+
+    const statCard = screen
+      .getByText("10+")
+      .closest("div[class]")?.parentElement;
+    if (!statCard) throw new Error("Experience card was not rendered");
+    fireEvent.mouseEnter(statCard);
+    expect(statCard.style.boxShadow).toContain("25px");
+    fireEvent.mouseLeave(statCard);
+    expect(statCard.style.boxShadow).toContain("10px");
+  });
+
+  it("switches to the journey timeline and back to the overview", () => {
+    render(<AboutSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Journey" }));
+    expect(screen.getByText("Started Coding")).toBeInTheDocument();
+    expect(screen.getByText("Founded Nifty League")).toBeInTheDocument();
+    expect(screen.queryByText("Innovation")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Overview" }));
+    expect(screen.getByText("Innovation")).toBeInTheDocument();
+  });
+});
+
+describe("PongHeader", () => {
+  it("renders the game and active navigation behavior", () => {
+    render(<PongHeader />);
+
+    expect(screen.getByTestId("pong-game")).toHaveAttribute(
+      "data-navbar-height",
+      "100",
+    );
+    expect(screen.getByTestId("pong-game")).toHaveTextContent(
+      "ANDREW M-F / CEO OF NIFTY LEAGUE",
+    );
+    expect(useScrollSpy).toHaveBeenCalledWith({
+      sectionIds: ["about", "skills", "projects", "contact"],
+      offset: 150,
+    });
+
+    const skills = screen.getByRole("button", { name: "SKILLS" });
+    expect(skills.style.borderColor).not.toBe("transparent");
+    const about = screen.getByRole("button", { name: "ABOUT" });
+    fireEvent.mouseEnter(about);
+    expect(about.style.color).not.toBe("");
+    fireEvent.mouseLeave(about);
+    fireEvent.click(about);
+    expect(smoothScrollToSection).toHaveBeenCalledWith("about", 100);
+  });
+
+  it("adds and removes the sticky navigation as the page crosses the header", async () => {
+    const { unmount } = render(<PongHeader />);
+    expect(screen.getAllByRole("navigation")).toHaveLength(1);
+
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 801,
+    });
+    fireEvent.scroll(window);
+    await waitFor(() =>
+      expect(screen.getAllByRole("navigation")).toHaveLength(2),
+    );
+
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 0 });
+    fireEvent.scroll(window);
+    await waitFor(() =>
+      expect(screen.getAllByRole("navigation")).toHaveLength(1),
+    );
+    unmount();
+  });
+
+  it("checks sticky state directly when animation frames are unavailable", async () => {
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 900,
+    });
+
+    render(<PongHeader />);
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("navigation")).toHaveLength(2),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from "node:url"
-import { defineConfig } from "vitest/config"
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   oxc: {
@@ -15,6 +15,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"],
+    testTimeout: 15_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "text-summary", "html", "lcov"],
@@ -29,11 +30,11 @@ export default defineConfig({
       ],
       exclude: ["components/ui/**", "**/*.d.ts", "**/types.ts"],
       thresholds: {
-        branches: 25,
-        functions: 25,
-        lines: 25,
-        statements: 25,
+        branches: 66,
+        functions: 74,
+        lines: 75,
+        statements: 76,
       },
     },
   },
-})
+});


### PR DESCRIPTION
## Summary

- add interaction tests for the About section, Pong header, sticky navigation, hover behavior, and tab state
- make the coverage run resilient under parallel CI load with a 15-second test timeout
- raise all enforced coverage floors to the new measured baseline

## Coverage

| Metric | Before | After | Enforced floor |
| --- | ---: | ---: | ---: |
| Statements | 59.02% | 76.29% | 76% |
| Branches | 49.52% | 66.03% | 66% |
| Functions | 43.87% | 74.83% | 74% |
| Lines | 61.55% | 75.88% | 75% |

The full suite now runs 16 tests.

## Validation

- `pnpm test:coverage`
- `pnpm typecheck`
- Prettier check for changed files
