### PR TITLE
staging sync: main merge + mobile coverage tests

### DIFF
--- a/tests/use-mobile.test.tsx
+++ b/tests/use-mobile.test.tsx
@@ -1,51 +1,51 @@
-import { afterEach, describe, expect, it, vi } from 'bun:test';
-import { renderHook } from '@testing-library/react';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { afterEach, describe, expect, it, vi } from 'bun:test'
+import { renderHook } from '@testing-library/react'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 describe('useIsMobile', () => {
   afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-  });
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
 
   it('returns false when viewport is at desktop width', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true })
     const mockMatchMedia = vi.fn().mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    });
-    window.matchMedia = mockMatchMedia;
+    })
+    window.matchMedia = mockMatchMedia
 
-    const { result } = renderHook(() => useIsMobile());
-    expect(result.current).toBe(false);
-  });
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
 
   it('returns true when viewport is below mobile breakpoint', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true });
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true })
     const mockMatchMedia = vi.fn().mockReturnValue({
       matches: true,
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-    });
-    window.matchMedia = mockMatchMedia;
+    })
+    window.matchMedia = mockMatchMedia
 
-    const { result } = renderHook(() => useIsMobile());
-    expect(result.current).toBe(true);
-  });
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
 
   it('registers a media query listener on mount', () => {
-    const removeEventListener = vi.fn();
+    const removeEventListener = vi.fn()
     const mockMatchMedia = vi.fn().mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
       removeEventListener,
-    });
-    window.matchMedia = mockMatchMedia;
+    })
+    window.matchMedia = mockMatchMedia
 
-    const { unmount } = renderHook(() => useIsMobile());
-    expect(mockMatchMedia).toHaveBeenCalledWith('(max-width: 767px)');
-    unmount();
-    expect(removeEventListener).toHaveBeenCalled();
-  });
-});
+    const { unmount } = renderHook(() => useIsMobile())
+    expect(mockMatchMedia).toHaveBeenCalledWith('(max-width: 767px)')
+    unmount()
+    expect(removeEventListener).toHaveBeenCalled()
+  })
+})

--- a/tests/use-mobile.test.tsx
+++ b/tests/use-mobile.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'bun:test';
 import { renderHook } from '@testing-library/react';
 import { useIsMobile } from '@/hooks/use-mobile';
 

--- a/tests/use-mobile.test.tsx
+++ b/tests/use-mobile.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+describe('useIsMobile', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns false when viewport is at desktop width', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    const mockMatchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    window.matchMedia = mockMatchMedia;
+
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when viewport is below mobile breakpoint', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true });
+    const mockMatchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    window.matchMedia = mockMatchMedia;
+
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('registers a media query listener on mount', () => {
+    const removeEventListener = vi.fn();
+    const mockMatchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener,
+    });
+    window.matchMedia = mockMatchMedia;
+
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(mockMatchMedia).toHaveBeenCalledWith('(max-width: 767px)');
+    unmount();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Merges `origin/main` into `staging` (Next 16 / Tailwind 4 / bun:test migration from #43/#44).
- Folds in `test/coverage-use-mobile-20260717-v2` → adds `useIsMobile` hook coverage (`tests/use-mobile.test.tsx`).
- Fixes a stale `vitest` import in that test file to `bun:test` (repo migrated off vitest in #43/#44).
- Deliberately skips `deps/auto-20260719` — it is an older automated dep-upgrade branch that main's controlled upgrade (#43/#44) already supersedes; merging it conflicted with bun.lock/package.json.

## Verification (pinned toolchain: bun@1.3.14, node@24.18.0 via mise)
- `bun run lint` → 0 warnings
- `bun run type:check` (tsc --noEmit) → clean
- `bun test --dom --isolate` → 40 pass / 0 fail

## Status
PR left OPEN pending CI + Vercel build green and review. Do NOT merge to main until both pass.
