### PR TITLE
test(brand-icons): add coverage for Github/Linkedin SVG components

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,3 @@ vercel env push .env.local
 ```
 
 > Never commit `.env.local` — it is gitignored. For team projects use `vercel --scope niftyleague`.
-> // staging sync: reset to main

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ vercel env push .env.local
 ```
 
 > Never commit `.env.local` — it is gitignored. For team projects use `vercel --scope niftyleague`.
+// staging sync: reset to main

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ vercel env push .env.local
 ```
 
 > Never commit `.env.local` — it is gitignored. For team projects use `vercel --scope niftyleague`.
-// staging sync: reset to main
+> // staging sync: reset to main

--- a/lib/brand-icons.test.tsx
+++ b/lib/brand-icons.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import { Github, Linkedin } from './brand-icons'
+
+describe('Github brand icon', () => {
+  it('renders an SVG with aria-hidden for accessibility', () => {
+    const { container } = render(<Github />)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('defaults to 24×24 when no size prop is given', () => {
+    const { container } = render(<Github />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('width')).toBe('24')
+    expect(svg?.getAttribute('height')).toBe('24')
+  })
+
+  it('applies a custom size to width and height', () => {
+    const { container } = render(<Github size={32} />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('width')).toBe('32')
+    expect(svg?.getAttribute('height')).toBe('32')
+  })
+
+  it('forwards additional HTML props like className', () => {
+    const { container } = render(<Github className="icon-large" />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('class')).toBe('icon-large')
+  })
+
+  it('renders a path element for the icon shape', () => {
+    const { container } = render(<Github />)
+    expect(container.querySelector('path')).not.toBeNull()
+  })
+})
+
+describe('Linkedin brand icon', () => {
+  it('renders an SVG with aria-hidden', () => {
+    const { container } = render(<Linkedin />)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('defaults to 24×24 when no size prop is given', () => {
+    const { container } = render(<Linkedin />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('width')).toBe('24')
+    expect(svg?.getAttribute('height')).toBe('24')
+  })
+
+  it('applies a custom size to width and height', () => {
+    const { container } = render(<Linkedin size={48} />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('width')).toBe('48')
+    expect(svg?.getAttribute('height')).toBe('48')
+  })
+
+  it('forwards additional HTML props', () => {
+    const { container } = render(<Linkedin id="linkedin-icon" />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('id')).toBe('linkedin-icon')
+  })
+
+  it('renders a path element for the icon shape', () => {
+    const { container } = render(<Linkedin />)
+    expect(container.querySelector('path')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Adds colocated tests for `lib/brand-icons.tsx`, covering both exported components (`Github` and `Linkedin`).

This was the only non-trivial source file in the project without test coverage.

## Changes

- **`lib/brand-icons.test.tsx`** — 10 tests (5 per component):
  - Renders SVG with `aria-hidden=true`
  - Defaults to 24×24 when no `size` prop
  - Applies custom `size` to `width`/`height`
  - Forwards extra HTML props (`className`, `id`)
  - Renders a `<path>` element

## Verification

- `bun run test` — 50 pass / 0 fail (was 40, added 10)
- `bun run format:check` — clean
- `bun run lint` — clean (0 warnings)
- `bun run type:check` — clean

## Risk

**LOW.** Pure component tests — no production code was modified, no runtime behavior changed.