### PR TITLE
test(typography): add coverage for Typography component

### DIFF
--- a/components/ui/typography.test.tsx
+++ b/components/ui/typography.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'bun:test'
+
+import {
+  SITE_HEADER_COLOR,
+  SITE_SUBHEADER_COLOR,
+  SITE_TEXT_COLOR,
+  SITE_SUBTEXT_COLOR,
+} from '@/constants/colors'
+import { Typography } from '@/components/ui/typography'
+
+describe('Typography', () => {
+  describe('variant', () => {
+    const cases: [string, string, RegExp][] = [
+      ['h1', 'h1', /font-pixel/],
+      ['h2', 'h2', /font-pixel/],
+      ['h3', 'h3', /font-semibold/],
+      ['h4', 'h4', /font-semibold/],
+      ['h5', 'h5', /font-semibold/],
+      ['h6', 'h6', /font-semibold/],
+      ['body1', 'p', /text-base/],
+      ['body2', 'p', /text-sm/],
+      ['caption', 'span', /text-xs/],
+      ['overline', 'span', /uppercase/],
+    ]
+
+    for (const [variant, expectedElement, classPattern] of cases) {
+      it(`renders as <${expectedElement}> with matching classes for variant="${variant}"`, () => {
+        const { container } = render(<Typography variant={variant as any}>{variant}</Typography>)
+
+        const el = container.querySelector(expectedElement)
+        expect(el).not.toBeNull()
+        expect(el?.textContent).toBe(variant)
+        expect(el?.className).toMatch(classPattern)
+      })
+    }
+
+    it('defaults to body1 when variant is omitted', () => {
+      const { container } = render(<Typography>default</Typography>)
+      const el = container.querySelector('p')
+      expect(el).not.toBeNull()
+      expect(el?.textContent).toBe('default')
+    })
+
+    it('gracefully handles an unknown variant by falling back to body1', () => {
+      const { container } = render(<Typography variant={'unknown' as any}>fallback</Typography>)
+      const el = container.querySelector('p')
+      expect(el).not.toBeNull()
+      expect(el?.textContent).toBe('fallback')
+    })
+  })
+
+  describe('color', () => {
+    const colorCases: [string, string][] = [
+      ['primary', SITE_HEADER_COLOR],
+      ['secondary', SITE_SUBHEADER_COLOR],
+      ['textPrimary', SITE_TEXT_COLOR],
+      ['textSecondary', SITE_SUBTEXT_COLOR],
+      ['inherit', 'inherit'],
+    ]
+
+    for (const [color, expectedCss] of colorCases) {
+      it(`applies color="${color}" as inline style "${expectedCss}"`, () => {
+        render(
+          <Typography color={color as any} variant="body1">
+            colored
+          </Typography>
+        )
+        const el = screen.getByText('colored')
+        expect(el.style.color).toBe(expectedCss)
+      })
+    }
+
+    it('falls back to SITE_TEXT_COLOR for an unknown color value', () => {
+      render(
+        <Typography color={'nonexistent' as any} variant="body1">
+          unknown
+        </Typography>
+      )
+      const el = screen.getByText('unknown')
+      expect(el.style.color).toBe(SITE_TEXT_COLOR)
+    })
+  })
+
+  describe('align', () => {
+    const alignCases: [string, RegExp][] = [
+      ['left', /text-left/],
+      ['center', /text-center/],
+      ['right', /text-right/],
+    ]
+
+    for (const [align, classPattern] of alignCases) {
+      it(`applies align="${align}" class`, () => {
+        const { container } = render(
+          <Typography align={align as any} variant="body1">
+            aligned
+          </Typography>
+        )
+        const el = container.querySelector('p')
+        expect(el?.className).toMatch(classPattern)
+      })
+    }
+
+    it('defaults to text-left when align is omitted', () => {
+      const { container } = render(<Typography variant="body1">default</Typography>)
+      const el = container.querySelector('p')
+      expect(el?.className).toMatch(/text-left/)
+    })
+  })
+
+  describe('gutterBottom', () => {
+    it('adds mb-4 when gutterBottom is true', () => {
+      const { container } = render(
+        <Typography variant="body1" gutterBottom>
+          gutter
+        </Typography>
+      )
+      const el = container.querySelector('p')
+      expect(el?.className).toContain('mb-4')
+    })
+
+    it('omits mb-4 when gutterBottom is false', () => {
+      const { container } = render(
+        <Typography variant="body1" gutterBottom={false}>
+          no-gutter
+        </Typography>
+      )
+      const el = container.querySelector('p')
+      expect(el?.className).not.toContain('mb-4')
+    })
+
+    it('omits mb-4 when gutterBottom is not set', () => {
+      const { container } = render(<Typography variant="body1">default</Typography>)
+      const el = container.querySelector('p')
+      expect(el?.className).not.toContain('mb-4')
+    })
+  })
+
+  describe('component override', () => {
+    it('renders the custom component instead of the variant default', () => {
+      render(
+        <Typography variant="h1" component="div">
+          override
+        </Typography>
+      )
+      const el = screen.getByText('override')
+      expect(el.tagName).toBe('DIV')
+      // Classes should still match the h1 variant
+      expect(el.className).toMatch(/font-pixel/)
+    })
+
+    it('accepts a custom component via component prop even for body variants', () => {
+      render(
+        <Typography variant="body1" component="article">
+          article-body
+        </Typography>
+      )
+      const el = screen.getByText('article-body')
+      expect(el.tagName).toBe('ARTICLE')
+    })
+  })
+
+  describe('className passthrough', () => {
+    it('merges additional className via cn()', () => {
+      const { container } = render(
+        <Typography variant="body1" className="my-custom-class">
+          custom
+        </Typography>
+      )
+      const el = container.querySelector('p')
+      expect(el?.className).toContain('my-custom-class')
+    })
+
+    it('preserves variant classes when className is added', () => {
+      const { container } = render(
+        <Typography variant="h1" className="extra-class">
+          extra
+        </Typography>
+      )
+      const el = container.querySelector('h1')
+      expect(el?.className).toContain('font-pixel')
+      expect(el?.className).toContain('extra-class')
+    })
+  })
+})

--- a/components/ui/typography.tsx
+++ b/components/ui/typography.tsx
@@ -48,7 +48,8 @@ export function Typography({
     overline: { element: 'span', classes: 'text-xs uppercase tracking-wide' },
   }
 
-  const { element: Element, classes } = variantMap[variant]
+  const resolved = variantMap[variant] ?? variantMap.body1
+  const { element: Element, classes } = resolved
   const Component = component || Element
   const style = { color: colorMap[color] || SITE_TEXT_COLOR }
 


### PR DESCRIPTION
## Summary

Adds a dedicated test suite for the `Typography` component (`components/ui/typography.tsx`), the single lowest-coverage non-trivial source file in the project (60 lines, zero dedicated tests).

## Changes

### New file: `components/ui/typography.test.tsx`
29 real behavioral tests covering:
- All 10 **variant** mappings (h1–h6, body1, body2, caption, overline) — verifies correct HTML element `and` Tailwind class output
- **Variant defaulting** — omitted and unknown variants fall back to body1
- All 5 **color** mappings (primary → `SITE_HEADER_COLOR`, secondary → `SITE_SUBHEADER_COLOR`, textPrimary → `SITE_TEXT_COLOR`, textSecondary → `SITE_SUBTEXT_COLOR`, inherit → `inherit`)
- **Fallback** for unknown color values → `SITE_TEXT_COLOR`
- All 3 **align** mappings (left, center, right) + omitted default
- **gutterBottom** — true adds `mb-4`, false/omitted omits it
- **component override** — uses custom element type instead of variant default
- **className passthrough** — preserves variant classes while merging extras

### Bug fix: `components/ui/typography.tsx`
The one-liner `const { element: Element, classes } = variantMap[variant]` throws a `TypeError` when called with an unknown variant value, because it destructures from `undefined`. Fixed by resolving through `?? variantMap.body1`.

## CI gates
- **Tests**: 69 pass / 0 fail (was 40 pass) — 29 new Typography tests
- **Lint**: 0 warnings
- **Type check**: clean
- **Format**: clean

## Coverage impact
Typography component: 0% → 100% line coverage (dedicated unit tests)
Project overall: \~95% → \~97% (estimated)

Closes: incremental coverage growth for 2026-07-24