### PR TITLE
chore: remove legacy eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}


### PR DESCRIPTION
Removes the legacy ESLint config now that the repository uses the canonical ESLint flat config.