### PR TITLE
perf(pong): eliminate per-frame array allocations in game loop

### DIFF
--- a/lib/games/pong/constants.ts
+++ b/lib/games/pong/constants.ts
@@ -7,7 +7,6 @@ export const PADDLE_SPEED = 0.25
 
 // Text rendering
 export const LETTER_SPACING = 1
-export const WORD_SPACING = 3
 export const LARGE_PIXEL_SIZE = 8
 export const SMALL_PIXEL_SIZE = 4
 export const TEXT_WIDTH_FACTOR = 0.8

--- a/lib/games/pong/game.ts
+++ b/lib/games/pong/game.ts
@@ -177,10 +177,10 @@ function checkPixelCollisions(game: GameState): Particle[] {
   const { ball, pixels } = game
   const newParticles: Particle[] = []
 
-  // Only check non-hit pixels for collision
-  const activePixels = pixels.filter((pixel) => !pixel.hit)
-
-  for (const pixel of activePixels) {
+  // Only check non-hit pixels for collision — iterate in place to avoid
+  // allocating a filtered array on every frame of the animation loop.
+  for (const pixel of pixels) {
+    if (pixel.hit) continue
     if (
       ball.x + ball.radius > pixel.x &&
       ball.x - ball.radius < pixel.x + pixel.size &&
@@ -226,18 +226,30 @@ function createParticles(pixel: Pixel, particles: Particle[]): void {
   }
 }
 
-// Update existing particles and add new ones
+// Advance a particle by one frame, returning true while it is still alive
+function advanceParticle(p: Particle): boolean {
+  p.x += p.dx
+  p.y += p.dy
+  p.life++
+  p.alpha = 1 - p.life / PARTICLE_LIFE
+  p.dx *= PARTICLE_DECAY
+  p.dy *= PARTICLE_DECAY
+  return p.life < PARTICLE_LIFE
+}
+
+// Update existing particles and add new ones — writes into a single survivor
+// array instead of spreading + filtering (which allocated two arrays per frame).
 function updateParticles(game: GameState, newParticles: Particle[]): void {
-  // Update existing particles
-  game.particles = [...game.particles, ...newParticles].filter((p) => {
-    p.x += p.dx
-    p.y += p.dy
-    p.life++
-    p.alpha = 1 - p.life / PARTICLE_LIFE
-    p.dx *= PARTICLE_DECAY
-    p.dy *= PARTICLE_DECAY
-    return p.life < PARTICLE_LIFE
-  })
+  const survivors: Particle[] = []
+
+  for (const p of game.particles) {
+    if (advanceParticle(p)) survivors.push(p)
+  }
+  for (const p of newParticles) {
+    if (advanceParticle(p)) survivors.push(p)
+  }
+
+  game.particles = survivors
 }
 
 // Optimized text generation with memoization for character maps

--- a/lib/games/pong/renderer.ts
+++ b/lib/games/pong/renderer.ts
@@ -34,34 +34,40 @@ export function render(ctx: CanvasRenderingContext2D, game: GameState): void {
   ctx.strokeText(scoreText, 20, 20)
 }
 
-// Optimized pixel rendering with batching by hit state
+// Optimized pixel rendering with batching by hit state — two in-place passes
+// keep the batched fillStyle/shadowBlur setup without allocating filtered
+// arrays on every frame of the animation loop.
 function renderPixels(
   ctx: CanvasRenderingContext2D,
   pixels: Pixel[],
   colors: GameState['colors']
 ): void {
   // First render non-hit pixels
-  const nonHitPixels = pixels.filter((p) => !p.hit)
-  const hitPixels = pixels.filter((p) => p.hit)
+  let nonHitBatchStarted = false
+  for (const pixel of pixels) {
+    if (pixel.hit) continue
 
-  if (nonHitPixels.length > 0) {
-    ctx.shadowColor = colors.pixel
-    ctx.shadowBlur = nonHitPixels[0].size * 0.5
-    ctx.fillStyle = colors.pixel
-
-    for (const pixel of nonHitPixels) {
-      ctx.fillRect(pixel.x, pixel.y, pixel.size, pixel.size)
+    if (!nonHitBatchStarted) {
+      nonHitBatchStarted = true
+      ctx.shadowColor = colors.pixel
+      ctx.shadowBlur = pixel.size * 0.5
+      ctx.fillStyle = colors.pixel
     }
+    ctx.fillRect(pixel.x, pixel.y, pixel.size, pixel.size)
   }
 
-  if (hitPixels.length > 0) {
-    ctx.shadowColor = colors.hitPixel
-    ctx.shadowBlur = hitPixels[0].size * 0.5
-    ctx.fillStyle = colors.hitPixel
+  // Then render hit pixels
+  let hitBatchStarted = false
+  for (const pixel of pixels) {
+    if (!pixel.hit) continue
 
-    for (const pixel of hitPixels) {
-      ctx.fillRect(pixel.x, pixel.y, pixel.size, pixel.size)
+    if (!hitBatchStarted) {
+      hitBatchStarted = true
+      ctx.shadowColor = colors.hitPixel
+      ctx.shadowBlur = pixel.size * 0.5
+      ctx.fillStyle = colors.hitPixel
     }
+    ctx.fillRect(pixel.x, pixel.y, pixel.size, pixel.size)
   }
 }
 


### PR DESCRIPTION
## Summary

The pong header animation loop runs at 60fps, and three hot paths allocated new arrays on **every frame** even though the pixel/particle sets rarely change:

| Location | Before | After |
|---|---|---|
| `checkPixelCollisions` | `pixels.filter(!hit)` per frame | in-place skip loop |
| `updateParticles` | spread + `.filter()` (2 allocations/frame) | single survivor array |
| `renderPixels` | two `.filter()` calls per frame | two in-place passes, batching preserved |

Also removes `WORD_SPACING` — an exported constant never imported anywhere in the codebase (dead code).

## Validation

- `bun run typecheck` ✓
- `bun test --dom --isolate` — 101 pass / 0 fail ✓
- `bun run lint` (eslint --max-warnings=0) ✓

No behavior change: identical draw-call order/count (renderer test pins `fillRect` count) and identical collision/particle semantics.

**Risk: LOW.**