### PR TITLE
fix(header): stabilize sticky scroll listener registration

### DIFF
--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -16,7 +16,11 @@ export function PongHeader() {
     offset: NAVBAR_HEIGHT + 50,
   })
 
-  // Helper function to check sticky state
+  // Helper function to check sticky state.
+  // Uses the functional setState form so the callback has no dependencies —
+  // React bails out when the state is unchanged, and the scroll listener is
+  // registered exactly once instead of being torn down/re-added on every
+  // sticky flip (same pattern as useScrollSpy).
   const checkStickyState = useCallback(() => {
     const scrollPosition = window.scrollY
     // The navbar should stick when we scroll past the header minus the navbar height
@@ -25,10 +29,8 @@ export function PongHeader() {
     const shouldBeSticky = scrollPosition > headerHeight
 
     // Only update state if the sticky state has changed
-    if (shouldBeSticky !== isSticky) {
-      setIsSticky(shouldBeSticky)
-    }
-  }, [isSticky])
+    setIsSticky((prev) => (prev === shouldBeSticky ? prev : shouldBeSticky))
+  }, [])
 
   // Optimized scroll handler with throttling and useCallback
   const handleScroll = useCallback(() => {

--- a/tests/about-header.test.tsx
+++ b/tests/about-header.test.tsx
@@ -121,4 +121,24 @@ describe('PongHeader', () => {
 
     await waitFor(() => expect(screen.getAllByRole('navigation')).toHaveLength(2))
   })
+
+  it('registers the scroll listener once across sticky state flips', async () => {
+    const addEventListener = spyOn(window, 'addEventListener')
+
+    const { unmount } = render(<PongHeader />)
+    expect(addEventListener.mock.calls.filter(([event]) => event === 'scroll')).toHaveLength(1)
+
+    // Flip sticky on, then off — the stable callback must not re-register
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 801 })
+    fireEvent.scroll(window)
+    await waitFor(() => expect(screen.getAllByRole('navigation')).toHaveLength(2))
+
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0 })
+    fireEvent.scroll(window)
+    await waitFor(() => expect(screen.getAllByRole('navigation')).toHaveLength(1))
+
+    expect(addEventListener.mock.calls.filter(([event]) => event === 'scroll')).toHaveLength(1)
+
+    unmount()
+  })
 })


### PR DESCRIPTION
## Summary

`PongHeader` had the exact scroll-listener re-registration bug that was already fixed in `useScrollSpy` (PR #71): `checkStickyState` closed over `isSticky`, so every sticky flip (scroll past header / scroll back up) recreated the callback → recreated `handleScroll` → the effect re-ran → the window `scroll` listener was torn down and re-added.

**Fix:** switch to the functional setState form — React bails out when the state is unchanged — making `checkStickyState` dependency-free. The listener is now registered exactly once for the header's lifetime.

## Validation

- New regression test: `registers the scroll listener once across sticky state flips` — **verified it fails against the old code** (5 pass / 1 fail) and passes with the fix
- `bun run typecheck` ✓
- `bun test --dom --isolate` — 102 pass / 0 fail ✓
- `bun run lint` ✓

No behavior change to the sticky UI itself — both existing sticky tests still pass.

**Risk: LOW.**