### PR TITLE
refactor(views): remove dead keyId prop and hoist contact lookups

### DIFF
--- a/views/about-section.tsx
+++ b/views/about-section.tsx
@@ -67,10 +67,8 @@ const TabButton = memo(function TabButton({
 
 // Memoized value card component
 const ValueCard = memo(function ValueCard({
-  keyId,
   value,
 }: {
-  keyId: string
   value: (typeof ABOUT_CONTENT.values)[keyof typeof ABOUT_CONTENT.values]
 }) {
   const IconComponent = ICON_MAP[value.icon as keyof typeof ICON_MAP]
@@ -111,7 +109,6 @@ const ValueCard = memo(function ValueCard({
 
   return (
     <Card
-      key={keyId}
       className="group border-0 transition-all duration-300 hover:scale-105"
       style={cardStyle}
       onMouseEnter={handleMouseEnter}
@@ -368,7 +365,7 @@ export const AboutSection = memo(function AboutSection() {
             {/* Overview Cards - Hidden on small screens */}
             <div className={cn('hidden gap-6 sm:gap-8 md:grid md:grid-cols-3')}>
               {valuesEntries.map(([key, value]) => (
-                <ValueCard key={key} keyId={key} value={value} />
+                <ValueCard key={key} value={value} />
               ))}
             </div>
 

--- a/views/contact-section.tsx
+++ b/views/contact-section.tsx
@@ -15,6 +15,20 @@ import { CONTACT_LINKS, CONTACT_CONTENT } from '@/constants/content'
 import { X, Mail } from 'lucide-react'
 import { Github, Linkedin } from '@/lib/brand-icons'
 
+// Hoisted platform lookups — CONTACT_LINKS is static, so the icon/URL
+// mappings are built once at module scope instead of per item per render.
+const CONTACT_ICONS = {
+  twitter: <X size={24} style={{ color: SITE_BTN_COLOR }} />,
+  github: <Github size={24} style={{ color: SITE_BTN_COLOR }} />,
+  linkedin: <Linkedin size={24} style={{ color: SITE_BTN_COLOR }} />,
+} as const
+
+const CONTACT_URLS = {
+  twitter: (handle: string) => `https://twitter.com/${handle.replace('@', '')}`,
+  github: (handle: string) => `https://github.com/${handle.replace('@', '')}`,
+  linkedin: (handle: string) => `https://linkedin.com/in/${handle.replace('@', '')}`,
+} as const
+
 export function ContactSection() {
   return (
     <Section id="contact">
@@ -27,31 +41,7 @@ export function ContactSection() {
         </Typography>
         <div className={cn('mb-8 grid grid-cols-1 gap-6 sm:mb-12 sm:grid-cols-3 sm:gap-8')}>
           {CONTACT_LINKS.map((contact, index) => {
-            const getIcon = (platform: string) => {
-              switch (platform.toLowerCase()) {
-                case 'twitter':
-                  return <X size={24} style={{ color: SITE_BTN_COLOR }} />
-                case 'github':
-                  return <Github size={24} style={{ color: SITE_BTN_COLOR }} />
-                case 'linkedin':
-                  return <Linkedin size={24} style={{ color: SITE_BTN_COLOR }} />
-                default:
-                  return null
-              }
-            }
-
-            const getUrl = (platform: string, handle: string) => {
-              switch (platform.toLowerCase()) {
-                case 'twitter':
-                  return `https://twitter.com/${handle.replace('@', '')}`
-                case 'github':
-                  return `https://github.com/${handle.replace('@', '')}`
-                case 'linkedin':
-                  return `https://linkedin.com/in/${handle.replace('@', '')}`
-                default:
-                  return '#'
-              }
-            }
+            const platform = contact.platform.toLowerCase() as keyof typeof CONTACT_ICONS
 
             return (
               <Card
@@ -70,7 +60,7 @@ export function ContactSection() {
               >
                 <CardContent className="p-4 sm:p-6">
                   <a
-                    href={getUrl(contact.platform, contact.handle)}
+                    href={CONTACT_URLS[platform]?.(contact.handle) ?? '#'}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="block text-center"
@@ -80,7 +70,7 @@ export function ContactSection() {
                         className="rounded-lg p-3 transition-transform duration-300 group-hover:scale-110"
                         style={{ backgroundColor: `${SITE_BTN_COLOR}20` }}
                       >
-                        {getIcon(contact.platform)}
+                        {CONTACT_ICONS[platform] ?? null}
                       </div>
                     </div>
                     <Typography variant="h3" align="center" color="secondary" gutterBottom>


### PR DESCRIPTION
## Summary

Two small cleanups in the view layer:

**`views/about-section.tsx`** — `ValueCard` accepted a `keyId` prop that was only used for `key={keyId}` on its root `Card` element. Keys only matter inside arrays (the parent already supplies `key={key}`), so the prop was pure dead code. Removed it.

**`views/contact-section.tsx`** — `getIcon`/`getUrl` were recreated inside the `.map()` callback on every render even though `CONTACT_LINKS` is static. Replaced with module-scope `CONTACT_ICONS` / `CONTACT_URLS` lookup tables. Same rendered URLs and icons, built once.

## Validation

- `bun run typecheck` ✓
- `bun test --dom --isolate` — 101 pass / 0 fail ✓
- `bun run lint` ✓

No behavior change — the contact-link hrefs render identically (verified by the existing components test asserting the GitHub link).

**Risk: LOW.**