### PR TITLE
perf(github): fetch pinned and popular repos concurrently

### DIFF
--- a/lib/github.test.ts
+++ b/lib/github.test.ts
@@ -50,4 +50,38 @@ describe('fetchPinnedRepos', () => {
     expect(repos.length).toBeGreaterThan(0)
     expect(repos.every((r) => Array.isArray(r.languages))).toBe(true)
   })
+
+  it('initiates pinned and popular repo fetches concurrently', async () => {
+    const requested: string[] = []
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => (release = resolve))
+
+    globalThis.fetch = mock(async (url: string) => {
+      const u = String(url)
+      requested.push(u)
+      if (u.includes('/languages')) return makeResponse({})
+      // Hold every request behind a gate so the test can observe which
+      // requests were initiated before any of them resolved.
+      await gate
+      if (u.includes('users/0xPlayerOne/repos')) {
+        return makeResponse([
+          repoJson('other-repo', 'An open project', 'https://github.com/0xPlayerOne/other-repo'),
+        ])
+      }
+      return makeResponse(
+        repoJson('nifty-fe', 'The monorepo', 'https://github.com/NiftyLeague/nifty-fe-monorepo')
+      )
+    }) as any
+
+    const pending = fetchPinnedRepos()
+    // Let the initial fetches start; nothing has resolved yet.
+    await Promise.resolve()
+
+    expect(requested.filter((u) => u.includes('/repos/NiftyLeague/'))).toHaveLength(2)
+    expect(requested.some((u) => u.includes('users/0xPlayerOne/repos'))).toBe(true)
+
+    release()
+    const repos = await pending
+    expect(repos.length).toBeGreaterThan(0)
+  })
 })

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -17,8 +17,12 @@ const GITHUB_FETCH_OPTIONS: RequestInit & { next: { revalidate: number } } = {
 
 export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
   try {
-    const pinnedRepos = await fetchSpecificRepos(PINNED_REPO_CONFIGS, true)
-    const popularRepos = await fetchPopularRepositories()
+    // Fetch pinned and popular repos concurrently — they are independent,
+    // so serializing them added a full network round-trip of latency.
+    const [pinnedRepos, popularRepos] = await Promise.all([
+      fetchSpecificRepos(PINNED_REPO_CONFIGS, true),
+      fetchPopularRepositories(),
+    ])
 
     // Filter out pinned repos from popular repos to avoid duplicates
     const pinnedUrls = pinnedRepos.map((repo) => repo.url)
@@ -31,6 +35,9 @@ export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
       MAX_PROJECTS
     )
 
+    // Resolve fallback languages once instead of re-spreading per repo
+    const fallbackProjects = [...FALLBACK_PINNED_REPOS, ...FALLBACK_POPULAR_REPOS]
+
     // Fetch languages for each repo
     const reposWithLanguages = await Promise.all(
       selectedRepos.map(async (repo) => {
@@ -41,7 +48,6 @@ export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
 
         // If languages fetch failed and this is a fallback project, use fallback languages
         if (languages.length === 0) {
-          const fallbackProjects = [...FALLBACK_PINNED_REPOS, ...FALLBACK_POPULAR_REPOS]
           const fallbackProject = fallbackProjects.find((p) => p.url === repo.url)
           if (fallbackProject) {
             languages = fallbackProject.languages
@@ -66,39 +72,43 @@ async function fetchSpecificRepos(
   repoConfigs: PinnedRepoConfig[],
   isPinned: boolean
 ): Promise<Omit<PinnedRepo, 'languages'>[]> {
-  const repos: Omit<PinnedRepo, 'languages'>[] = []
+  // Fetch all configured repos concurrently; each request keeps its own
+  // try/catch so a single failure (e.g. rate limit) never drops the batch.
+  const results = await Promise.all(
+    repoConfigs.map(async (config): Promise<Omit<PinnedRepo, 'languages'> | null> => {
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${config.owner}/${config.repo}`,
+          GITHUB_FETCH_OPTIONS
+        )
 
-  for (const config of repoConfigs) {
-    try {
-      const response = await fetch(
-        `https://api.github.com/repos/${config.owner}/${config.repo}`,
-        GITHUB_FETCH_OPTIONS
-      )
+        if (response.status === 403) {
+          console.warn(`Rate limited for ${config.owner}/${config.repo}`)
+          return null
+        }
 
-      if (response.status === 403) {
-        console.warn(`Rate limited for ${config.owner}/${config.repo}`)
-        continue
+        if (response.ok) {
+          const repo: GitHubRepo = await response.json()
+          return {
+            title: config.displayName || formatRepoName(repo.name),
+            description: repo.description || 'No description available',
+            tech: repo.topics.slice(0, 4),
+            url: repo.html_url,
+            homepage: repo.homepage || undefined,
+            stars: repo.stargazers_count,
+            forks: repo.forks_count,
+            isPinned,
+          }
+        }
+      } catch (error) {
+        console.error(`Error fetching repo ${config.owner}/${config.repo}:`, error)
       }
 
-      if (response.ok) {
-        const repo: GitHubRepo = await response.json()
-        repos.push({
-          title: config.displayName || formatRepoName(repo.name),
-          description: repo.description || 'No description available',
-          tech: repo.topics.slice(0, 4),
-          url: repo.html_url,
-          homepage: repo.homepage || undefined,
-          stars: repo.stargazers_count,
-          forks: repo.forks_count,
-          isPinned,
-        })
-      }
-    } catch (error) {
-      console.error(`Error fetching repo ${config.owner}/${config.repo}:`, error)
-    }
-  }
+      return null
+    })
+  )
 
-  return repos
+  return results.filter((repo): repo is Omit<PinnedRepo, 'languages'> => repo !== null)
 }
 
 async function fetchPopularRepositories(): Promise<Omit<PinnedRepo, 'languages'>[]> {


### PR DESCRIPTION
## Summary

The projects section previously serialized network round-trips:

1. `fetchSpecificRepos` fetched the pinned repos one-by-one in a `for` loop
2. `fetchPinnedRepos` awaited pinned repos *before* starting the popular-repos request

Both are independent, so this wasted a full round-trip of latency on every load/refresh.

**Changes:**
- `fetchSpecificRepos` → `Promise.all` across configured repos; each request keeps its own try/catch, so a single failure (or the 403 rate-limit path) still only drops that repo
- `fetchPinnedRepos` → pinned + popular fetches run concurrently via `Promise.all`
- Fallback-language list built once instead of re-spread per repo

## Validation

- New gated regression test: `initiates pinned and popular repo fetches concurrently` — asserts both pinned configs + the popular request are in flight before any resolves; **verified it fails against the old sequential code** (2 pass / 1 fail) and passes with the fix
- `bun run typecheck` ✓
- `bun test --dom --isolate` — 102 pass / 0 fail ✓
- `bun run lint` ✓

Same result data, same order (pinned first, then popular by popularity score). Rate-limit request count is unchanged — only the timing differs.

**Risk: LOW.**