### PR TITLE
fix(deps): restore dependabot ignore rules for typescript/eslint major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
     groups:
       npm-dependencies:
         patterns: ['*']
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: cargo
     directory: /
     target-branch: staging


### PR DESCRIPTION
## Summary

Commit `6f85b7e` (runtime bump to v0.32.3) accidentally **reverted** the dependabot `ignore` rules for `typescript` and `eslint` major bumps that were added in `b52d2d5`.

## Why it matters

Without the ignore rules, dependabot generated PR #93 (eslint `9.39.5 → 10.8.0` + typescript `6.0.3 → 7.0.2`, both **semver-major**), which fails **all** CI checks with:

```
error: lockfile had changes, but lockfile is frozen
```

## Changes implemented

- Restored the `ignore:` block under the `npm-dependencies` group in `.github/dependabot.yml`:
  - `typescript` → no `version-update:semver-major`
  - `eslint` → no `version-update:semver-major`

## Risk assessment

**LOW.** Config-only change matching the project's own prior intent (`b52d2d5`). No code, lockfile, or runtime impact.