### PR TITLE
refactor: hoist static maps, dedupe repo mapping, coalesce rAF scroll handlers

### DIFF
--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { RetroCanvas } from './retro-canvas'
 import { RetroNavbar } from './retro-navbar'
 import { useScrollSpy } from '@/hooks/use-scroll-spy'
@@ -33,13 +33,23 @@ export function PongHeader() {
   }, [])
 
   // Optimized scroll handler with throttling and useCallback
+  const rafIdRef = useRef<number>(0)
   const handleScroll = useCallback(() => {
     if (!window.requestAnimationFrame) {
       checkStickyState()
       return
     }
 
-    window.requestAnimationFrame(checkStickyState)
+    // Coalesce scroll events: cancel any pending frame so at most one
+    // callback runs per animation frame instead of queueing one callback
+    // per scroll event.
+    if (rafIdRef.current) {
+      cancelAnimationFrame(rafIdRef.current)
+    }
+    rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = 0
+      checkStickyState()
+    })
   }, [checkStickyState])
 
   useEffect(() => {
@@ -49,6 +59,9 @@ export function PongHeader() {
     handleScroll()
 
     return () => {
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
       window.removeEventListener('scroll', handleScroll)
     }
   }, [handleScroll])

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -6,5 +6,3 @@ export const NAVIGATION_SECTIONS = [
   { id: 'projects', label: 'PROJECTS' },
   { id: 'contact', label: 'CONTACT' },
 ] as const
-
-export type NavigationSection = (typeof NAVIGATION_SECTIONS)[number]['id']

--- a/hooks/use-scroll-spy.ts
+++ b/hooks/use-scroll-spy.ts
@@ -45,13 +45,23 @@ export const useScrollSpy = ({ sectionIds, offset = 0 }: UseScrollSpyProps) => {
   }, [sectionIdsArray, offset])
 
   // Throttle scroll handler for better performance
+  const rafIdRef = useRef<number>(0)
   const handleScroll = useCallback(() => {
     // Use requestAnimationFrame for better performance
     if (!window.requestAnimationFrame) {
       return throttledScrollHandler()
     }
 
-    window.requestAnimationFrame(throttledScrollHandler)
+    // Coalesce scroll events: cancel any pending frame so at most one
+    // callback runs per animation frame instead of queueing one callback
+    // per scroll event (trackpad/rapid scroll can fire several per frame).
+    if (rafIdRef.current) {
+      cancelAnimationFrame(rafIdRef.current)
+    }
+    rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = 0
+      throttledScrollHandler()
+    })
   }, [throttledScrollHandler])
 
   useEffect(() => {
@@ -62,6 +72,9 @@ export const useScrollSpy = ({ sectionIds, offset = 0 }: UseScrollSpyProps) => {
     handleScroll()
 
     return () => {
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
       window.removeEventListener('scroll', handleScroll)
     }
   }, [handleScroll])

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -89,16 +89,7 @@ async function fetchSpecificRepos(
 
         if (response.ok) {
           const repo: GitHubRepo = await response.json()
-          return {
-            title: config.displayName || formatRepoName(repo.name),
-            description: repo.description || 'No description available',
-            tech: repo.topics.slice(0, 4),
-            url: repo.html_url,
-            homepage: repo.homepage || undefined,
-            stars: repo.stargazers_count,
-            forks: repo.forks_count,
-            isPinned,
-          }
+          return toPinnedRepo(repo, isPinned, config.displayName)
         }
       } catch (error) {
         console.error(`Error fetching repo ${config.owner}/${config.repo}:`, error)
@@ -143,16 +134,7 @@ async function fetchPopularRepositories(): Promise<Omit<PinnedRepo, 'languages'>
         return scoreB - scoreA
       })
 
-    return popularRepos.map((repo) => ({
-      title: formatRepoName(repo.name),
-      description: repo.description || 'No description available',
-      tech: repo.topics.slice(0, 4),
-      url: repo.html_url,
-      homepage: repo.homepage || undefined,
-      stars: repo.stargazers_count,
-      forks: repo.forks_count,
-      isPinned: false,
-    }))
+    return popularRepos.map((repo) => toPinnedRepo(repo, false))
   } catch (error) {
     console.error('Error fetching popular repos:', error)
     return FALLBACK_POPULAR_REPOS
@@ -193,6 +175,23 @@ async function fetchRepoLanguages(
   } catch (error) {
     console.error(`Error fetching languages for ${owner}/${repoName}:`, error)
     return []
+  }
+}
+
+function toPinnedRepo(
+  repo: GitHubRepo,
+  isPinned: boolean,
+  displayName?: string
+): Omit<PinnedRepo, 'languages'> {
+  return {
+    title: displayName || formatRepoName(repo.name),
+    description: repo.description || 'No description available',
+    tech: repo.topics.slice(0, 4),
+    url: repo.html_url,
+    homepage: repo.homepage || undefined,
+    stars: repo.stargazers_count,
+    forks: repo.forks_count,
+    isPinned,
   }
 }
 

--- a/lib/language-colors.ts
+++ b/lib/language-colors.ts
@@ -1,25 +1,27 @@
 import { SITE_BTN_COLOR } from '@/constants/colors'
-export const getLanguageColor = (language: string) => {
-  const colors: Record<string, string> = {
-    TypeScript: '#3178c6',
-    JavaScript: '#f1e05a',
-    Python: '#3572A5',
-    Solidity: '#AA6746',
-    Go: '#00ADD8',
-    Rust: '#dea584',
-    'C#': '#239120',
-    Java: '#b07219',
-    'C++': '#f34b7d',
-    HTML: '#e34c26',
-    CSS: '#1572B6',
-    Vue: '#4FC08D',
-    React: '#61DAFB',
-    Swift: '#FA7343',
-    Kotlin: '#A97BFF',
-    Dart: '#00B4AB',
-    PHP: '#777BB4',
-    Ruby: '#701516',
-    Shell: '#89e051',
-  }
-  return colors[language] || SITE_BTN_COLOR
+
+// Hoisted to module scope — this map is static and was previously re-created
+// on every getLanguageColor() call from inside the render loop.
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  Solidity: '#AA6746',
+  Go: '#00ADD8',
+  Rust: '#dea584',
+  'C#': '#239120',
+  Java: '#b07219',
+  'C++': '#f34b7d',
+  HTML: '#e34c26',
+  CSS: '#1572B6',
+  Vue: '#4FC08D',
+  React: '#61DAFB',
+  Swift: '#FA7343',
+  Kotlin: '#A97BFF',
+  Dart: '#00B4AB',
+  PHP: '#777BB4',
+  Ruby: '#701516',
+  Shell: '#89e051',
 }
+
+export const getLanguageColor = (language: string) => LANGUAGE_COLORS[language] || SITE_BTN_COLOR


### PR DESCRIPTION
## Summary

Performance and dead-code cleanup across the render loop and scroll handlers.

## Changes implemented

**Performance wins:**
- `lib/language-colors.ts` — hoisted the static `LANGUAGE_COLORS` map to module scope. It was previously re-created on **every** `getLanguageColor()` call inside the projects render loop.
- `hooks/use-scroll-spy.ts` + `components/header/index.tsx` — rAF coalescing: cancel any pending animation frame before scheduling the next scroll callback. Previously every scroll event queued its own callback; under rapid scroll (trackpad/wheel) multiple callbacks could run per frame. Also cancels the pending frame on unmount cleanup.

**Refactor / DRY:**
- `lib/github.ts` — extracted shared `toPinnedRepo()` helper, removing the duplicated `GitHubRepo → PinnedRepo` mapping in `fetchSpecificRepos` and `fetchPopularRepositories` (identical 9-field object shape in both).

**Dead code removed:**
- `constants/navigation.ts` — removed the unused `NavigationSection` type export (verified: never imported).

## Validation

| Check | Result |
|---|---|
| `bun run format:check` | ✅ All files pass Prettier |
| `bun run lint` | ✅ 0 warnings (`--max-warnings=0`) |
| `bun run typecheck` | ✅ `tsc --noEmit` clean |
| `bun test --dom --isolate` | ✅ 103/103 pass (incl. scroll-spy + header rAF tests) |

## Risk assessment

**LOW.** Behavior-preserving refactor; the rAF coalescing only changes *when* the scroll callback runs (at most once per frame instead of possibly multiple), and all existing scroll/sticky tests pass.