### PR TITLE
Promote staging -> main (2026-08-02)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       github-actions:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: npm
     directory: /
@@ -19,6 +20,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       npm-dependencies:
+        applies-to: version-updates
         patterns: ['*']
     ignore:
       - dependency-name: 'typescript'
@@ -34,6 +36,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       cargo-dependencies:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: pip
     directory: /
@@ -44,4 +47,5 @@ updates:
     open-pull-requests-limit: 99
     groups:
       python-dependencies:
+        applies-to: version-updates
         patterns: ['*']


### PR DESCRIPTION
## Environment promotion

Promote the validated `staging` environment into `main`.
This is a deployment-promotion PR, not the version-release PR.

- **Source:** `staging`
- **Target:** `main`
- **Changes:** 5 changes
- **Created:** 2026-08-02

### Commit summary

- refactor: hoist static maps, dedupe repo mapping, coalesce rAF scroll (#95) (a2f37ac)
- fix(deps): restore dependabot ignore rules for typescript/eslint majors (#94) (7bc9f38)
- chore(deps): update portfolio dependencies and Vercel gate (#98) (53cf5c2)
- test: split and expand coverage (#100) (8ed6ef4)
- ci: split Dependabot security updates (#101) (a747c09)

### Validation

- Required CI, test, security, and CodeQL checks must pass before merge.
- Merge using the repository's configured `merge_strategy` (**rebase**).
- The promotion topology requires rebase; never merge a promotion PR with a merge commit.
- After merge, Release Please opens a separate versioned release PR with the changelog.
