### PR TITLE
chore(ci): align Code Foundry release policy

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.34.4
+runtime_ref: v0.34.13
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest
@@ -35,4 +35,4 @@ custom_workflows: preserve
 codeql_rust_shards: '["all"]'
 codeql_rust_threads: 1
 codeql_rust_max_parallel: 1
-release_merge_strategy: squash
+release_merge_strategy: rebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.34.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.4
+      runtime-ref: v0.34.13
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,10 +18,10 @@ permissions:
 jobs:
   codeql:
     name: CodeQL
-    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.34.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.4
+      runtime-ref: v0.34.13
       runner: ubuntu-latest
       rust-shards: '["all"]'
       rust-threads: '1'

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.34.13
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,7 +18,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.head_ref, 'release-please--branches--main')
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.34.13
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.34.13
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.4
+      runtime-ref: v0.34.13
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   security:
     name: Security
-    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.34.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.4
+      runtime-ref: v0.34.13
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.34.4
+    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.34.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.34.4
+      runtime-ref: v0.34.13
       runner: ubuntu-latest
       unit-runner: ubuntu-slim
     secrets: inherit


### PR DESCRIPTION
Align the consumer with Code Foundry v0.34.13 and the repository merge rules:

- pin generated Code Foundry workflow references to v0.34.13
- require rebase for Release Please version PRs into main

Only standard Code Foundry references and .github/code-foundry.yml are changed. Repository-owned custom workflows remain intact.