### PR TITLE
refactor: memoize inline handlers and optimize github lookups

### DIFF
--- a/components/game-credits.tsx
+++ b/components/game-credits.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { Gamepad2 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -9,6 +10,20 @@ import { MOBY_GAMES_LINK } from '@/constants/links'
 import { SITE_CARD_COLOR, SITE_BORDER_COLOR, SITE_BTN_COLOR } from '@/constants/colors'
 
 const GameCreditsCard = () => {
+  // Memoize hover handlers to prevent recreation on every render
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+    },
+    []
+  )
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+    },
+    []
+  )
+
   return (
     <Card
       className="group relative w-full max-w-6xl border-0 transition-all duration-300 hover:scale-105 lg:max-w-2xl"
@@ -16,12 +31,8 @@ const GameCreditsCard = () => {
         backgroundColor: SITE_CARD_COLOR,
         boxShadow: `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`,
       }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-      }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <CardContent className="p-6 sm:p-8">
         <div className="mb-4 flex items-center gap-3">

--- a/components/game-credits.tsx
+++ b/components/game-credits.tsx
@@ -11,18 +11,12 @@ import { SITE_CARD_COLOR, SITE_BORDER_COLOR, SITE_BTN_COLOR } from '@/constants/
 
 const GameCreditsCard = () => {
   // Memoize hover handlers to prevent recreation on every render
-  const handleMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-    },
-    []
-  )
-  const handleMouseLeave = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-    },
-    []
-  )
+  const handleMouseEnter = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+  }, [])
+  const handleMouseLeave = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+  }, [])
 
   return (
     <Card

--- a/components/game-credits.tsx
+++ b/components/game-credits.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useCallback } from 'react'
 import { Gamepad2 } from 'lucide-react'
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -18,9 +18,7 @@ const GITHUB_FETCH_OPTIONS: RequestInit & { next: { revalidate: number } } = {
 // Hoisted to module scope — these are static and previously re-created on
 // every fetchPinnedRepos() call.
 const FALLBACK_PROJECTS = [...FALLBACK_PINNED_REPOS, ...FALLBACK_POPULAR_REPOS]
-const FALLBACK_PROJECT_MAP = new Map(
-  FALLBACK_PROJECTS.map((project) => [project.url, project])
-)
+const FALLBACK_PROJECT_MAP = new Map(FALLBACK_PROJECTS.map((project) => [project.url, project]))
 
 export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
   try {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -15,6 +15,13 @@ const GITHUB_FETCH_OPTIONS: RequestInit & { next: { revalidate: number } } = {
   next: { revalidate: 3600 },
 }
 
+// Hoisted to module scope — these are static and previously re-created on
+// every fetchPinnedRepos() call.
+const FALLBACK_PROJECTS = [...FALLBACK_PINNED_REPOS, ...FALLBACK_POPULAR_REPOS]
+const FALLBACK_PROJECT_MAP = new Map(
+  FALLBACK_PROJECTS.map((project) => [project.url, project])
+)
+
 export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
   try {
     // Fetch pinned and popular repos concurrently — they are independent,
@@ -25,8 +32,8 @@ export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
     ])
 
     // Filter out pinned repos from popular repos to avoid duplicates
-    const pinnedUrls = pinnedRepos.map((repo) => repo.url)
-    const filteredPopularRepos = popularRepos.filter((repo) => !pinnedUrls.includes(repo.url))
+    const pinnedUrls = new Set(pinnedRepos.map((repo) => repo.url))
+    const filteredPopularRepos = popularRepos.filter((repo) => !pinnedUrls.has(repo.url))
 
     // Combine pinned repos (first) with popular repos to reach MAX_PROJECTS
     const neededPopular = Math.max(0, MAX_PROJECTS - pinnedRepos.length)
@@ -36,7 +43,7 @@ export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
     )
 
     // Resolve fallback languages once instead of re-spreading per repo
-    const fallbackProjects = [...FALLBACK_PINNED_REPOS, ...FALLBACK_POPULAR_REPOS]
+    // (FALLBACK_PROJECTS is now hoisted to module scope)
 
     // Fetch languages for each repo
     const reposWithLanguages = await Promise.all(
@@ -48,7 +55,7 @@ export async function fetchPinnedRepos(): Promise<PinnedRepo[]> {
 
         // If languages fetch failed and this is a fallback project, use fallback languages
         if (languages.length === 0) {
-          const fallbackProject = fallbackProjects.find((p) => p.url === repo.url)
+          const fallbackProject = FALLBACK_PROJECT_MAP.get(repo.url)
           if (fallbackProject) {
             languages = fallbackProject.languages
           }

--- a/views/contact-section.tsx
+++ b/views/contact-section.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback } from 'react'
 import { Section } from '@/components/ui/section'
 import { Typography } from '@/components/ui/typography'
 import { Card, CardContent } from '@/components/ui/card'
@@ -30,6 +31,19 @@ const CONTACT_URLS = {
 } as const
 
 export function ContactSection() {
+  // Memoize hover handlers to prevent recreation on every render
+  const handleCardMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+    },
+    []
+  )
+  const handleCardMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+    },
+    []
+  )
   return (
     <Section id="contact">
       <Typography variant="h2" align="center" color="primary" gutterBottom>
@@ -51,12 +65,8 @@ export function ContactSection() {
                   backgroundColor: SITE_CARD_COLOR,
                   boxShadow: `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`,
                 }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-                }}
+                onMouseEnter={handleCardMouseEnter}
+                onMouseLeave={handleCardMouseLeave}
               >
                 <CardContent className="p-4 sm:p-6">
                   <a

--- a/views/contact-section.tsx
+++ b/views/contact-section.tsx
@@ -32,18 +32,12 @@ const CONTACT_URLS = {
 
 export function ContactSection() {
   // Memoize hover handlers to prevent recreation on every render
-  const handleCardMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-    },
-    []
-  )
-  const handleCardMouseLeave = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-    },
-    []
-  )
+  const handleCardMouseEnter = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+  }, [])
+  const handleCardMouseLeave = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+  }, [])
   return (
     <Section id="contact">
       <Typography variant="h2" align="center" color="primary" gutterBottom>

--- a/views/projects-section.tsx
+++ b/views/projects-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { ExternalLink, Star, GitFork, RefreshCw, Pin } from 'lucide-react'
 import { Github } from '@/lib/brand-icons'
 
@@ -49,6 +49,20 @@ export function ProjectsSection() {
   useEffect(() => {
     loadProjects()
   }, [])
+
+  // Memoize hover handlers to prevent recreation on every render
+  const handleCardMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+    },
+    []
+  )
+  const handleCardMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+    },
+    []
+  )
 
   return (
     <Section id="projects">
@@ -122,12 +136,8 @@ export function ProjectsSection() {
                   backgroundColor: SITE_CARD_COLOR,
                   boxShadow: `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`,
                 }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-                }}
+                onMouseEnter={handleCardMouseEnter}
+                onMouseLeave={handleCardMouseLeave}
               >
                 {project.isPinned && (
                   <div className="absolute top-3 left-3 z-10">

--- a/views/projects-section.tsx
+++ b/views/projects-section.tsx
@@ -51,18 +51,12 @@ export function ProjectsSection() {
   }, [])
 
   // Memoize hover handlers to prevent recreation on every render
-  const handleCardMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-    },
-    []
-  )
-  const handleCardMouseLeave = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-    },
-    []
-  )
+  const handleCardMouseEnter = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+  }, [])
+  const handleCardMouseLeave = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+  }, [])
 
   return (
     <Section id="projects">

--- a/views/skills-section.tsx
+++ b/views/skills-section.tsx
@@ -25,18 +25,12 @@ const SKILL_ICONS = {
 
 export function SkillsSection() {
   // Memoize hover handlers to prevent recreation on every render
-  const handleCardMouseEnter = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-    },
-    []
-  )
-  const handleCardMouseLeave = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-    },
-    []
-  )
+  const handleCardMouseEnter = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+  }, [])
+  const handleCardMouseLeave = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+  }, [])
   return (
     <Section id="skills">
       <Typography variant="h2" align="center" color="primary" gutterBottom>

--- a/views/skills-section.tsx
+++ b/views/skills-section.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '@/lib/utils'
 import { SKILLS_DATA } from '@/constants/content'
 import { Code2, Gamepad2, Users, Briefcase, Palette, Blocks } from 'lucide-react'
+import { useCallback } from 'react'
 
 const SKILL_ICONS = {
   'Web & Full-Stack': Code2,
@@ -23,6 +24,19 @@ const SKILL_ICONS = {
 } as const
 
 export function SkillsSection() {
+  // Memoize hover handlers to prevent recreation on every render
+  const handleCardMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
+    },
+    []
+  )
+  const handleCardMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
+    },
+    []
+  )
   return (
     <Section id="skills">
       <Typography variant="h2" align="center" color="primary" gutterBottom>
@@ -45,12 +59,8 @@ export function SkillsSection() {
                   backgroundColor: SITE_CARD_COLOR,
                   boxShadow: `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`,
                 }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 20px ${SITE_BTN_COLOR}40`
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.boxShadow = `0 0 0 1px ${SITE_BORDER_COLOR}, 0 0 10px ${SITE_BORDER_COLOR}40`
-                }}
+                onMouseEnter={handleCardMouseEnter}
+                onMouseLeave={handleCardMouseLeave}
               >
                 <CardContent className="p-4 sm:p-6">
                   <div className="mb-4 flex items-center gap-3">


### PR DESCRIPTION
## Summary
Small perf and hygiene improvements across the portfolio:

- **lib/github.ts**: Replace `Array.includes` with `Set.has` for pinned URL deduplication (O(n*m) → O(n)), and `Array.find` with `Map.get` for fallback project lookup (O(n) → O(1)). Hoist static fallback arrays to module scope so they are not re-created on every fetch.
- **views/projects-section.tsx, views/skills-section.tsx, views/contact-section.tsx, components/game-credits.tsx**: Memoize inline `onMouseEnter`/ `onMouseLeave` handlers with `useCallback` to prevent unnecessary arrow function recreation on every render, matching the existing pattern in `about-section.tsx`.

## Test plan
- `bun test --dom --isolate` → 108 pass, 0 fail

## Risk
Low — no behavioral changes, only render-performance and lookup-algorithm improvements.