### PR TITLE
chore: align staging with main (2026-08-08)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ docs/*  test/*  refactor/*         │              │
 | `staging`                                                      | Integration branch       | Target normal pull requests here. Required checks must pass before merge. |
 | `feat/*`, `fix/*`, `chore/*`, `refactor/*`, `docs/*`, `test/*` | Focused work             | Branch from `staging`; keep changes small and reviewable.                 |
 
-The default Git workflow is `staging-release`: topic branches merge into `staging`, then a promotion PR moves validated changes into `main`, followed by the versioned release PR. The default merge strategy is `rebase`, which preserves the linear Conventional Commit history. Configure `merge_strategy` as `squash` or `merge` in `.github/code-foundry.yml` when the repository intentionally uses another policy. Re-align `staging` with `main` after a release when needed.
+The Git workflow is `staging-release`: topic branches **squash** into `staging`, a promotion PR **rebases** validated changes into `main` (`merge_strategy: rebase`), and the Release Please version PR **rebases** into `main` (`release_merge_strategy: rebase`). Release automation never defaults to a merge method and never merges with `--admin`; `code-foundry doctor` and `code-foundry sync` fail closed on any other merge strategy. Re-align `staging` with `main` after a release when needed.
 
 ## Before you start
 
@@ -107,7 +107,7 @@ For maintainers, trusted contributors, and automation agents:
 
 8. Push the branch and open a pull request into `staging`.
 9. Address review feedback and failed checks on the same branch.
-10. Merge using the repository's configured `merge_strategy` after required checks pass and the change is ready.
+10. Merge with a squash after required checks pass and the change is ready; feature PRs land on `staging` with squash merges.
 
 ### Internal agent handoff
 
@@ -153,17 +153,19 @@ Keep pull requests focused and reviewable. Include screenshots or recordings for
 
 ## Workflow and check behavior
 
-| Event                            | Expected automation                      |
-| -------------------------------- | ---------------------------------------- |
-| Push to `main` or `staging`      | CI, Test, Security, and CodeQL workflows |
-| Pull request targeting `staging` | CI, Test, Security, and CodeQL workflows |
-| Push to a working branch         | Draft PR workflow                        |
-| Push to `staging`                | Release PR workflow                      |
-| Version tag such as `v1.2.3`     | Release workflow                         |
+| Event                                              | Expected automation                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Pull request targeting `staging`                   | Fast validation: CI plus unit tests, ending in `Validation / Gate`                    |
+| Ordinary pull request targeting `main`             | Audit validation: CI, full tests, Security, and CodeQL, ending in `Validation / Gate` |
+| Exact Release Please pull request targeting `main` | Release-policy validation only, ending in `Validation / Gate`                         |
+| Scheduled or manual validation                     | Full audit tier                                                                       |
+| Push to a working branch                           | Draft PR workflow                                                                     |
+| Push to `staging`                                  | Promotion PR workflow; canonical validation waits for the PR event                    |
+| Push to `main`                                     | Release workflow; canonical validation already ran on the merged PR                   |
 
-The workflows use separate concurrency groups keyed by the commit under test. A newer run for the same commit cancels a duplicate event-triggered run, while newer commits cancel older runs and independent CI, Test, Security, and CodeQL workflows continue in parallel.
+The single validation caller keys concurrency by event and pull-request head. A newer update to the same pull request cancels its superseded validation run; scheduled and manual audits remain independent. The mode-aware orchestrator fans out only the jobs required by that event and always concludes with the stable aggregate gate.
 
-Required checks are enforced by branch protection. Do not duplicate their checklists in the pull request description; document validation commands and results instead.
+Required checks are enforced by branch protection rulesets/branch protection. Do not duplicate their checklists in the pull request description; document validation commands and results instead.
 
 ### Release conventions
 
@@ -173,10 +175,11 @@ Security checks can be skipped when repository visibility or the GitHub plan doe
 
 ## Review and merge protocol
 
-| Change            | Target    | Merge gate                                                |
-| ----------------- | --------- | --------------------------------------------------------- |
-| Working branch    | `staging` | All applicable required checks pass                       |
-| `staging` release | `main`    | Current staging checks, release review, and rollout notes |
+| Change                       | Target    | Merge method                                    | Merge gate                                                |
+| ---------------------------- | --------- | ----------------------------------------------- | --------------------------------------------------------- |
+| Working branch               | `staging` | Squash                                          | All applicable required checks pass                       |
+| `staging` → `main` promotion | `main`    | Rebase (`merge_strategy`)                       | Current staging checks, release review, and rollout notes |
+| Release Please version PR    | `main`    | Rebase (`release_merge_strategy`, fails closed) | Validation gate and release policy pass                   |
 
 Reviewers focus on correctness, security, maintainability, test coverage, operational impact, and compatibility. Authors remain responsible for responding to feedback and verifying the final commit.
 

--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.37.0
+runtime_ref: v0.37.1
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest

--- a/.github/security-audit-allowlist.txt
+++ b/.github/security-audit-allowlist.txt
@@ -5,3 +5,8 @@ GHSA-mh99-v99m-4gvg
 
 # js-yaml 3.x/4.x advisory (CVE-2026-59870): fix only lands in 5.x and is not backported.
 GHSA-5p4m-2wfm-xmqj
+
+# nanoid 3.x advisory (GHSA-2v37-7h3g-55p8): transitive through postcss 8.x
+# required by Tailwind; the fixed nanoid requires postcss 8.5.26+ which pins
+# the ecosystem. Revisit on the next postcss bump.
+GHSA-2v37-7h3g-55p8

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.37.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.37.1
     with:
       runner: ubuntu-slim
       base: staging

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-pr:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.37.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.37.1
     with:
       runner: ubuntu-slim
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.37.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.37.1
     with:
       runner: ubuntu-slim
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.37.0
+      runtime-ref: v0.37.1
     secrets:
       CODE_FOUNDRY_TOKEN: ${{ secrets.CODE_FOUNDRY_TOKEN }}
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: 0xPlayerOne/code-foundry
-          ref: v0.37.0
+          ref: v0.37.1
           path: .github/.code-foundry
           sparse-checkout: |
             src/lib
@@ -64,11 +64,11 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.37.0
+    uses: 0xPlayerOne/code-foundry/.github/workflows/validation.yml@v0.37.1
     with:
       mode: ${{ needs.mode.outputs.mode }}
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.37.0
+      runtime-ref: v0.37.1
       ci-runner: ubuntu-latest
       test-runner: ubuntu-latest
       unit-runner: ubuntu-slim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,12 @@ Ask for clarification when a missing decision would materially change the implem
 
 For normal feature work, branch from `staging` and target pull requests at `staging`. Treat `main` as the protected release branch. Follow `.github/CONTRIBUTING.md` for the complete internal and external contribution flow.
 
+## Git workflow and merging
+
+This repository uses the `staging-release` workflow: topic branches **squash** into `staging`, a promotion PR **rebases** validated changes into `main` (`merge_strategy: rebase`), and the Release Please version PR **rebases** into `main` (`release_merge_strategy: rebase`). Feature PRs land on `staging` with squash merges; promotion and release PRs land on `main` with rebase merges. Re-align `staging` with `main` after a release when needed.
+
+Merge only with the repository's canonical method. Never merge with `--admin`, never default or auto-select a merge method, and never use a method the branch ruleset does not allow. When in doubt, prefer the merge button's configured method and verify the ruleset after merging. Check `.github/CONTRIBUTING.md` for the complete flow and merge table.
+
 ## Toolchain and dependencies
 
 - Follow `toolchain: auto` in `.github/code-foundry.yml`; use native tools by

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,7 @@
-Copyright (C) 2026 NiftyAndy
+Copyright (C) 2026 0xPlayerOne
 
-This repository is distributed under agpl-3.0-or-later.
+This repository is distributed under the GNU Affero General Public License
+version 3 or later (AGPL-3.0-or-later). The complete license text is available
+at https://www.gnu.org/licenses/agpl-3.0.txt.
+
+Individual files may retain their original copyright and license notices.


### PR DESCRIPTION
## Summary

Aligns `staging` with `main` after the 2026-08-07 promote (#130) and subsequent syncs. Rebase discipline check showed `staging` was behind `main`:

- **Main has 7 commits staging lacks**: nanoid allowlist fix (`5563710`), code-foundry protected-docs sync to v0.37.1 (`34b6b47`), promote #130, and runtime pins (v0.36.1/v0.36.2/v0.37.0).
- **All staging-only commits are already incorporated into main** (verified: `git diff origin/main origin/staging` shows only main-ahead content; no genuine staging-only work remains).

This branch is built **from `staging`** and applies main's exact delta as a single commit, so the merge is clean (tree verified identical to `origin/main`).

## Changes

| File | Change |
|------|--------|
| `.github/code-foundry.yml` | `runtime_ref: v0.37.0` → `v0.37.1` |
| `.github/workflows/validation.yml` | code-foundry refs `v0.37.0` → `v0.37.1` |
| `.github/security-audit-allowlist.txt` | add nanoid `GHSA-2v37-7h3g-55p8` allowlist entry |
| `AGENTS.md` | drop superseded "Git workflow and merging" section (code-foundry v0.37.1 sync) |
| `NOTICE` | synced license/copyright header (code-foundry v0.37.1 protected docs) |
| `.github/CONTRIBUTING.md`, `draft-pr.yml`, `release-pr.yml`, `release.yml` | v0.37.1 sync alignment |

## Risk Assessment

**LOW** — CI config/docs only; no source code changes. Resulting `staging` tree is byte-identical to `main`'s tree, whose content already passed the `Validation / Gate` check on the protected branch.