### PR TITLE
refactor: use stable React keys for list renders

### DIFF
--- a/components/game-credits.tsx
+++ b/components/game-credits.tsx
@@ -48,8 +48,8 @@ const GameCreditsCard = () => {
         </div>
 
         <div className="mb-6">
-          {GAME_CREDITS.map((credit, index) => (
-            <div key={index} className="my-2 flex items-center justify-between">
+          {GAME_CREDITS.map((credit) => (
+            <div key={credit.title} className="my-2 flex items-center justify-between">
               <a
                 href={credit.link}
                 target="_blank"

--- a/views/about-section.tsx
+++ b/views/about-section.tsx
@@ -371,8 +371,8 @@ export const AboutSection = memo(function AboutSection() {
 
             {/* Stats Cards - Always visible */}
             <div className={cn('grid grid-cols-2 gap-6 sm:gap-8 lg:grid-cols-4')}>
-              {statsItems.map((stat, index) => (
-                <StatCard key={index} stat={stat} />
+              {statsItems.map((stat) => (
+                <StatCard key={stat.label} stat={stat} />
               ))}
             </div>
           </div>
@@ -386,8 +386,8 @@ export const AboutSection = memo(function AboutSection() {
               <div className="absolute top-0 bottom-0 left-8 w-0.5" style={timelineLineStyle} />
 
               <div className="space-y-8">
-                {journeyItems.map((item, index) => (
-                  <JourneyItem key={index} item={item} />
+                {journeyItems.map((item) => (
+                  <JourneyItem key={item.title} item={item} />
                 ))}
               </div>
             </div>

--- a/views/contact-section.tsx
+++ b/views/contact-section.tsx
@@ -48,12 +48,12 @@ export function ContactSection() {
           {CONTACT_CONTENT.description}
         </Typography>
         <div className={cn('mb-8 grid grid-cols-1 gap-6 sm:mb-12 sm:grid-cols-3 sm:gap-8')}>
-          {CONTACT_LINKS.map((contact, index) => {
+          {CONTACT_LINKS.map((contact) => {
             const platform = contact.platform.toLowerCase() as keyof typeof CONTACT_ICONS
 
             return (
               <Card
-                key={index}
+                key={contact.platform}
                 className="group cursor-pointer border-0 transition-all duration-300 hover:scale-105"
                 style={{
                   backgroundColor: SITE_CARD_COLOR,

--- a/views/projects-section.tsx
+++ b/views/projects-section.tsx
@@ -122,9 +122,9 @@ export function ProjectsSection() {
           </div>
         ) : (
           <div className={cn('grid grid-cols-1 gap-6 sm:gap-8 lg:grid-cols-2')}>
-            {projects.map((project, index) => (
+            {projects.map((project) => (
               <Card
-                key={index}
+                key={project.url}
                 className="group relative border-0 transition-all duration-300 hover:scale-105"
                 style={{
                   backgroundColor: SITE_CARD_COLOR,

--- a/views/skills-section.tsx
+++ b/views/skills-section.tsx
@@ -38,7 +38,7 @@ export function SkillsSection() {
       </Typography>
       <div className="mx-auto mt-8 max-w-6xl">
         <div className={cn('grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3')}>
-          {SKILLS_DATA.map((skillGroup, index) => {
+          {SKILLS_DATA.map((skillGroup) => {
             const IconComponent = SKILL_ICONS[skillGroup.category as keyof typeof SKILL_ICONS]
             const skills: ReadonlyArray<{ name: string; level: number }> = skillGroup.skills
             const avgLevel = Math.round(
@@ -47,7 +47,7 @@ export function SkillsSection() {
 
             return (
               <Card
-                key={index}
+                key={skillGroup.category}
                 className="group border-0 transition-all duration-300 hover:scale-105 hover:shadow-lg"
                 style={{
                   backgroundColor: SITE_CARD_COLOR,


### PR DESCRIPTION
## Summary

Replace array-index React keys with stable, unique identifiers across the list renders. Index keys cause React to mis-attribute DOM nodes when list order/content changes; the projects list is fetched from the GitHub API and re-sorted on every refresh, making it the highest-impact case.

## Changes Implemented

| File | Key change |
|------|-----------|
| `views/projects-section.tsx` | `key={index}` → `key={project.url}` (dynamic GitHub data — **real fix**) |
| `views/contact-section.tsx` | `key={index}` → `key={contact.platform}` |
| `components/game-credits.tsx` | `key={index}` → `key={credit.title}` |
| `views/about-section.tsx` | stats: `key={stat.label}`; journey: `key={item.title}` |
| `views/skills-section.tsx` | `key={skillGroup.category}` |

Skeleton placeholder cards in `projects-section` intentionally keep index keys (static placeholder array, no identity).

## Validation

- `bun run lint` — **PASS** (0 warnings)
- `bun run typecheck` — **PASS**
- `bun test --dom --isolate` — **PASS** (108 tests, 259 assertions)

## Risk Assessment

**LOW** — presentational-only change; no behavior, styling, or data-shape modifications. All existing tests pass unchanged.