### PR TITLE
refactor: remove dead ABOUT_CONTENT.mission conditional

### DIFF
--- a/constants/content.ts
+++ b/constants/content.ts
@@ -60,7 +60,6 @@ export const SKILLS_DATA = [
 export const ABOUT_CONTENT = {
   intro:
     "I'm a passionate developer and entrepreneur with a focus on AI, gaming, blockchain, and innovative digital experiences. My journey combines technical expertise with business acumen, creating products that push the boundaries of what's possible in the digital space.",
-  mission: '',
   stats: [
     { label: 'Years Experience', value: '10+', icon: 'zap' },
     { label: 'Projects Shipped', value: '50+', icon: 'rocket' },

--- a/views/about-section.tsx
+++ b/views/about-section.tsx
@@ -355,11 +355,6 @@ export const AboutSection = memo(function AboutSection() {
               <Typography variant="body1" align="center" gutterBottom>
                 {ABOUT_CONTENT.intro}
               </Typography>
-              {ABOUT_CONTENT.mission ? (
-                <Typography variant="body1" align="center" gutterBottom>
-                  {ABOUT_CONTENT.mission}
-                </Typography>
-              ) : null}
             </div>
 
             {/* Overview Cards - Hidden on small screens */}


### PR DESCRIPTION
## Summary

`ABOUT_CONTENT.mission` was always `''`, so the ternary in `views/about-section.tsx` could never render — dead code.

## Changes

- Removed the `mission: ''` field from `constants/content.ts`
- Removed the never-true `{ABOUT_CONTENT.mission ? ... : null}` branch from `views/about-section.tsx`

## Validation

- `bun test --coverage --dom --isolate`: **108 pass / 0 fail**
- Coverage: 96.58% statements / **97.03% branches** (up from 97.00% — dead branch eliminated)
- `bun run lint`: clean; `bun run typecheck`: clean; `bun run format:check`: clean

## Risk

**LOW.** No visible behavior change (the mission paragraph never rendered). If a mission statement is added later, the field and render branch can be restored together.